### PR TITLE
Fix tests: set env vars, adjust imports and data

### DIFF
--- a/functions/src/extract/index.test.ts
+++ b/functions/src/extract/index.test.ts
@@ -112,6 +112,7 @@ describe("extract (HTTP Function)", () => {
       .post("/")
       .send({
         transcript: "Texto clínico...",
+        language: "es-AR",
         correlationId: "xyz-999"
       })
       .set("Content-Type", "application/json");

--- a/functions/src/pipeline/index.test.ts
+++ b/functions/src/pipeline/index.test.ts
@@ -4,13 +4,13 @@ const transcribeServiceMock = jest.fn();
 const extractServiceMock = jest.fn();
 const diagnoseServiceMock = jest.fn();
 
-jest.mock("../transcribe/service.js", () => ({
+jest.mock("../transcribe/service", () => ({
   transcribeService: transcribeServiceMock,
 }));
-jest.mock("../extract/service.js", () => ({
+jest.mock("../extract/service", () => ({
   extractService: extractServiceMock,
 }));
-jest.mock("../diagnose/service.js", () => ({
+jest.mock("../diagnose/service", () => ({
   diagnoseService: diagnoseServiceMock,
 }));
 

--- a/functions/src/pipeline/index.ts
+++ b/functions/src/pipeline/index.ts
@@ -5,9 +5,9 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { z } from "zod";
 
-import { transcribeService, type TranscribeInput } from "../transcribe/service.js";
-import { extractService, type ExtractionResponseData } from "../extract/service.js";
-import { diagnoseService } from "../diagnose/service.js";
+import { transcribeService, type TranscribeInput } from "../transcribe/service";
+import { extractService, type ExtractionResponseData } from "../extract/service";
+import { diagnoseService } from "../diagnose/service";
 
 // -------- Secrets (para despliegue / emulador con .secret.local) --------
 const OPENAI_API_KEY = defineSecret("OPENAI_API_KEY");

--- a/functions/src/transcribe/index.test.ts
+++ b/functions/src/transcribe/index.test.ts
@@ -24,9 +24,16 @@ function buildJsonApp() {
 }
 
 describe("transcribe (contrato JSON + raw fallback)", () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
+    process.env = { ...originalEnv, OPENAI_API_KEY: "test" } as NodeJS.ProcessEnv;
     createMock.mockReset().mockResolvedValue({ text: "Texto (mock)" });
     fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   // ---------- JSON inválido ----------


### PR DESCRIPTION
## Summary
- ensure transcribe tests set OPENAI_API_KEY
- remove `.js` extensions from pipeline module imports
- require language in extract invalid JSON test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b437b94832c9fce73abfd062887