### PR TITLE
Evitar edad 0 y sexo X cuando faltan datos

### DIFF
--- a/functions/src/extract/index.test.ts
+++ b/functions/src/extract/index.test.ts
@@ -116,6 +116,39 @@ describe("extract (HTTP Function)", () => {
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
 
+  test("200 OK - LLM devuelve edad 0 y sexo X", async () => {
+    const llmData = {
+      patient: { age: 0, sex: "X" },
+      symptoms: ["tos"],
+    };
+
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        { message: { content: JSON.stringify(llmData) } }
+      ]
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post("/")
+      .send({
+        transcript: "Paciente consulta por tos",
+        language: "es-AR",
+        correlationId: "sin-edad-sex",
+      })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.correlationId).toBe("sin-edad-sex");
+    expect(res.body.data).toEqual({
+      symptoms: ["tos"],
+      riskFlags: [],
+    });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
   test("500 INTERNAL_ERROR - body incompleto", async () => {
     const app = buildApp();
 

--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -99,9 +99,9 @@ function normalizeExtractionData(raw: any): any {
       if (!Number.isNaN(num)) p.age = num;
       else delete p.age;
     }
-    if (p.age == null || Number.isNaN(p.age)) delete p.age;
+    if (p.age == null || Number.isNaN(p.age) || p.age === 0) delete p.age;
     if (typeof p.sex === "string") p.sex = p.sex.toUpperCase();
-    if (p.sex == null || !["M", "F", "X"].includes(p.sex)) delete p.sex;
+    if (p.sex == null || !["M", "F"].includes(p.sex)) delete p.sex;
     if (Object.keys(p).length > 0) out.patient = p;
     else delete out.patient;
   }


### PR DESCRIPTION
## Resumen
- Ignora valores de edad 0 y sexo "X" provenientes del LLM para omitir datos no especificados.
- Agrega prueba que valida que dichos valores no se incluyan en la respuesta de extracción.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5d76f924832cbfeb10aafabc41a6