### PR TITLE
refactor: mover prompt de extracción a variable de entorno

### DIFF
--- a/functions/src/extract/index.test.ts
+++ b/functions/src/extract/index.test.ts
@@ -19,10 +19,21 @@ jest.mock("openai", () => {
 
 describe("extract (HTTP Function)", () => {
   const originalEnv = process.env;
+  const prompt =
+    "Eres un asistente de extracción clínica. Extrae SOLO los campos solicitados. " +
+    "No inventes datos. Si algo no está, omítelo. Devuelve JSON válido que cumpla con el schema. " +
+    "Usa claves EXACTAS del schema en inglés (patient, symptoms, onsetDays, riskFlags, notes, sex, age). " +
+    "Mantén los valores de texto en el mismo idioma del texto de entrada. " +
+    "No envíes texto fuera del JSON.";
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...originalEnv, OPENAI_API_KEY: "test-key", OPENAI_MODEL: "gpt-4o-mini" };
+    process.env = {
+      ...originalEnv,
+      OPENAI_API_KEY: "test-key",
+      OPENAI_MODEL: "gpt-4o-mini",
+      LLM_EXTRACT_PROMPT: prompt,
+    };
     mockCreate.mockReset();
   });
 

--- a/functions/src/extract/index.test.ts
+++ b/functions/src/extract/index.test.ts
@@ -116,6 +116,39 @@ describe("extract (HTTP Function)", () => {
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
 
+  test("200 OK - LLM devuelve edad 0 y sexo X", async () => {
+    const llmData = {
+      patient: { age: 0, sex: "X" },
+      symptoms: ["tos"],
+    };
+
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        { message: { content: JSON.stringify(llmData) } }
+      ]
+    });
+
+    const app = buildApp();
+
+    const res = await request(app)
+      .post("/")
+      .send({
+        transcript: "Paciente consulta por tos",
+        language: "es-AR",
+        correlationId: "sin-edad-sex",
+      })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.correlationId).toBe("sin-edad-sex");
+    expect(res.body.data).toEqual({
+      symptoms: ["tos"],
+      riskFlags: [],
+    });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
   test("500 INTERNAL_ERROR - body incompleto", async () => {
     const app = buildApp();
 

--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -121,12 +121,8 @@ async function extractWithLLM(
   const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
   const openai = new OpenAI({ apiKey });
 
-  const system =
-    "Eres un asistente de extracción clínica. Extrae SOLO los campos solicitados. " +
-    "No inventes datos. Si algo no está, omítelo. Devuelve JSON válido que cumpla con el schema. " +
-    "Usa claves EXACTAS del schema en inglés (patient, symptoms, onsetDays, riskFlags, notes, sex, age). " +
-    "Mantén los valores de texto en el mismo idioma del texto de entrada. " +
-    "No envíes texto fuera del JSON.";
+  const system = process.env.LLM_EXTRACT_PROMPT;
+  if (!system) throw new Error("LLM_EXTRACT_PROMPT no está seteada");
 
   const user =
     `Texto clínico (lang=${language || "es-AR"}):\n\n${transcript}\n\n` +

--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -125,6 +125,7 @@ async function extractWithLLM(
     "Eres un asistente de extracción clínica. Extrae SOLO los campos solicitados. " +
     "No inventes datos. Si algo no está, omítelo. Devuelve JSON válido que cumpla con el schema. " +
     "Usa claves EXACTAS del schema en inglés (patient, symptoms, onsetDays, riskFlags, notes, sex, age). " +
+    "Mantén los valores de texto en el mismo idioma del texto de entrada. " +
     "No envíes texto fuera del JSON.";
 
   const user =

--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -99,9 +99,9 @@ function normalizeExtractionData(raw: any): any {
       if (!Number.isNaN(num)) p.age = num;
       else delete p.age;
     }
-    if (p.age == null || Number.isNaN(p.age)) delete p.age;
+    if (p.age == null || Number.isNaN(p.age) || p.age === 0) delete p.age;
     if (typeof p.sex === "string") p.sex = p.sex.toUpperCase();
-    if (p.sex == null || !["M", "F", "X"].includes(p.sex)) delete p.sex;
+    if (p.sex == null || !["M", "F"].includes(p.sex)) delete p.sex;
     if (Object.keys(p).length > 0) out.patient = p;
     else delete out.patient;
   }

--- a/functions/src/pipeline/index.test.ts
+++ b/functions/src/pipeline/index.test.ts
@@ -124,6 +124,68 @@ describe("pipeline", () => {
     });
   });
 
+  test("text input en-US -> extract and diagnose", async () => {
+    const extracted = {
+      patient: { age: 40, sex: "F" },
+      symptoms: ["cough"],
+      riskFlags: [],
+      onsetDays: 2,
+      notes: "",
+    };
+    const diagnosis = {
+      summary: "ok",
+      differentials: [],
+      recommendations: [],
+      severity: "low" as const,
+    };
+    extractServiceMock.mockResolvedValueOnce(extracted);
+    diagnoseServiceMock.mockResolvedValueOnce(diagnosis);
+
+    const { pipeline } = require("./index");
+
+    const res = await request(pipeline)
+      .post("/")
+      .send({ input: { text: "Patient", language: "en-US", correlationId: "corr-en" } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.correlationId).toBe("corr-en");
+    expect(res.body.transcript).toBe("Patient");
+    expect(res.body.extracted).toEqual(extracted);
+    expect(res.body.diagnosis).toEqual(diagnosis);
+
+    expect(transcribeServiceMock).not.toHaveBeenCalled();
+    expect(extractServiceMock).toHaveBeenCalledWith({
+      transcript: "Patient",
+      language: "en-US",
+      correlationId: "corr-en",
+    });
+    expect(diagnoseServiceMock).toHaveBeenCalledWith({
+      extraction: {
+        patient: extracted.patient,
+        symptoms: extracted.symptoms,
+        riskFlags: extracted.riskFlags,
+        onsetDays: extracted.onsetDays,
+        notes: extracted.notes,
+      },
+      language: "en-US",
+      correlationId: "corr-en",
+    });
+  });
+
+  test("unsupported language -> 400", async () => {
+    const { pipeline } = require("./index");
+    const res = await request(pipeline)
+      .post("/")
+      .send({ input: { text: "Paciente", language: "fr-FR", correlationId: "corr-3" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe("unsupported language");
+    expect(extractServiceMock).not.toHaveBeenCalled();
+    expect(diagnoseServiceMock).not.toHaveBeenCalled();
+  });
+
   test("invalid body -> 400", async () => {
     const { pipeline } = require("./index");
     const res = await request(pipeline).post("/").send({ foo: "bar" });

--- a/functions/src/pipeline/index.test.ts
+++ b/functions/src/pipeline/index.test.ts
@@ -173,11 +173,99 @@ describe("pipeline", () => {
     });
   });
 
+  test("audio input en-US -> extract and diagnose", async () => {
+    const trResult = { text: "Patient", language: "en", correlationId: "corr-a1" };
+    const extracted = {
+      patient: { age: 40, sex: "F" },
+      symptoms: ["cough"],
+      riskFlags: [],
+      onsetDays: 2,
+      notes: "",
+    };
+    const diagnosis = {
+      summary: "ok",
+      differentials: [],
+      recommendations: [],
+      severity: "low" as const,
+    };
+    transcribeServiceMock.mockResolvedValueOnce(trResult);
+    extractServiceMock.mockResolvedValueOnce(extracted);
+    diagnoseServiceMock.mockResolvedValueOnce(diagnosis);
+
+    const { pipeline } = require("./index");
+
+    const res = await request(pipeline)
+      .post("/")
+      .send({
+        input: {
+          audio: { type: "url", value: "https://example.com/audio.ogg" },
+          filename: "audio.ogg",
+          correlationId: "corr-a1",
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.correlationId).toBe("corr-a1");
+    expect(res.body.transcript).toBe("Patient");
+    expect(res.body.extracted).toEqual(extracted);
+    expect(res.body.diagnosis).toEqual(diagnosis);
+
+    expect(transcribeServiceMock).toHaveBeenCalledWith({
+      audio: { type: "url", value: "https://example.com/audio.ogg" },
+      filename: "audio.ogg",
+      language: undefined,
+      hint: undefined,
+      correlationId: "corr-a1",
+    });
+    expect(extractServiceMock).toHaveBeenCalledWith({
+      transcript: "Patient",
+      language: "en",
+      correlationId: "corr-a1",
+    });
+    expect(diagnoseServiceMock).toHaveBeenCalledWith({
+      extraction: {
+        patient: extracted.patient,
+        symptoms: extracted.symptoms,
+        riskFlags: extracted.riskFlags,
+        onsetDays: extracted.onsetDays,
+        notes: extracted.notes,
+      },
+      language: "en",
+      correlationId: "corr-a1",
+    });
+  });
+
   test("unsupported language -> 400", async () => {
     const { pipeline } = require("./index");
     const res = await request(pipeline)
       .post("/")
       .send({ input: { text: "Paciente", language: "fr-FR", correlationId: "corr-3" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe("unsupported language");
+    expect(extractServiceMock).not.toHaveBeenCalled();
+    expect(diagnoseServiceMock).not.toHaveBeenCalled();
+  });
+
+  test("audio input unsupported language -> 400", async () => {
+    transcribeServiceMock.mockResolvedValueOnce({
+      text: "Bonjour",
+      language: "fr",
+      correlationId: "corr-fr",
+    });
+
+    const { pipeline } = require("./index");
+
+    const res = await request(pipeline)
+      .post("/")
+      .send({
+        input: {
+          audio: { type: "url", value: "https://example.com/audio.ogg" },
+          correlationId: "corr-fr",
+        },
+      });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);

--- a/functions/src/transcribe/service.ts
+++ b/functions/src/transcribe/service.ts
@@ -72,13 +72,16 @@ export async function transcribeService(input: TranscribeInput): Promise<Transcr
   const out = await client.audio.transcriptions.create({
     model: "whisper-1",
     file: uploadable,
-    language,
+    ...(language ? { language } : {}),
     prompt: hint,
-  });
+    response_format: "verbose_json",
+  } as any);
+
+  const detected = normalizeLanguage((out as any).language);
 
   return {
     text: out.text,
-    language: language || "es",
+    language: detected || language || "",
     correlationId: input.correlationId,
   };
 }


### PR DESCRIPTION
## Summary
- read extraction system prompt from `LLM_EXTRACT_PROMPT`
- set test environment for extraction prompt
- remove committed `.env` from functions

## Testing
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba657b6124832c80341286789affc3