### PR TITLE
Add components diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Telepatia technical test backend based on Firebase Functions. The functions use OpenAI and Gemini models to transcribe audio, extract information, and suggest preliminary diagnoses.
 
+## Components Diagram
+
+![Components Diagram](components-diagram.svg)
+
 ## Requirements
 - Node.js 22
 - [Firebase CLI](https://firebase.google.com/docs/cli) installed globally

--- a/components-diagram.svg
+++ b/components-diagram.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="500">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="black" />
+    </marker>
+  </defs>
+
+  <!-- Outer container -->
+  <rect x="10" y="10" width="880" height="480" fill="none" stroke="black" />
+  <text x="450" y="30" font-size="18" text-anchor="middle">Telepatia Doctor Helper</text>
+
+  <!-- Actor -->
+  <circle cx="60" cy="250" r="20" stroke="black" fill="none" />
+  <line x1="60" y1="270" x2="60" y2="310" stroke="black" />
+  <line x1="40" y1="290" x2="80" y2="290" stroke="black" />
+  <line x1="60" y1="310" x2="40" y2="350" stroke="black" />
+  <line x1="60" y1="310" x2="80" y2="350" stroke="black" />
+  <text x="60" y="370" font-size="12" text-anchor="middle">Actor</text>
+
+  <!-- Device -->
+  <rect x="110" y="210" width="60" height="80" rx="8" ry="8" stroke="black" fill="none" />
+  <text x="140" y="310" font-size="12" text-anchor="middle">Device</text>
+
+  <!-- Arrow from device to firebase -->
+  <line x1="170" y1="250" x2="300" y2="250" stroke="black" marker-end="url(#arrow)" />
+  <text x="235" y="240" font-size="12" text-anchor="middle">audio / text</text>
+  <text x="235" y="260" font-size="12" text-anchor="middle">diagnosis</text>
+
+  <!-- Firebase container -->
+  <rect x="300" y="80" width="300" height="260" stroke="black" fill="none" />
+  <text x="450" y="100" font-size="14" text-anchor="middle">firebase (serverless)</text>
+
+  <!-- Firebase stages -->
+  <rect x="320" y="140" width="80" height="80" stroke="black" fill="none" />
+  <text x="360" y="185" font-size="12" text-anchor="middle">transcribe</text>
+
+  <rect x="410" y="140" width="80" height="80" stroke="black" fill="none" />
+  <text x="450" y="185" font-size="12" text-anchor="middle">extract</text>
+
+  <rect x="500" y="140" width="80" height="80" stroke="black" fill="none" />
+  <text x="540" y="185" font-size="12" text-anchor="middle">diagnose</text>
+
+  <!-- Arrow from firebase to result -->
+  <line x1="600" y1="250" x2="730" y2="250" stroke="black" marker-end="url(#arrow)" />
+  <text x="665" y="240" font-size="12" text-anchor="middle">result</text>
+
+  <!-- OpenAI container -->
+  <rect x="300" y="360" width="180" height="120" stroke="black" fill="none" />
+  <text x="390" y="380" font-size="14" text-anchor="middle">OpenAI</text>
+  <rect x="310" y="400" width="70" height="60" stroke="black" fill="none" />
+  <text x="345" y="435" font-size="12" text-anchor="middle">Whisper</text>
+  <rect x="380" y="400" width="80" height="60" stroke="black" fill="none" />
+  <text x="420" y="435" font-size="12" text-anchor="middle">LLM</text>
+
+  <!-- Gemini container -->
+  <rect x="500" y="360" width="180" height="120" stroke="black" fill="none" />
+  <text x="590" y="380" font-size="14" text-anchor="middle">Gemini</text>
+  <rect x="510" y="400" width="160" height="60" stroke="black" fill="none" />
+  <text x="590" y="435" font-size="12" text-anchor="middle">LLM</text>
+
+  <!-- Connections between firebase and providers -->
+  <line x1="540" y1="220" x2="390" y2="360" stroke="black" marker-end="url(#arrow)" />
+  <line x1="540" y1="220" x2="590" y2="360" stroke="black" marker-end="url(#arrow)" />
+
+</svg>


### PR DESCRIPTION
## Summary
- document architecture with a new Components Diagram section
- add SVG diagram illustrating data flow between Firebase and model providers

## Testing
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba70ee788c832c8e1bf9e74a272a00