### PR TITLE
feat: load extraction prompt from file

### DIFF
--- a/functions/prompts/llm_extract_prompt.md
+++ b/functions/prompts/llm_extract_prompt.md
@@ -1,0 +1,1 @@
+Eres un asistente de extracción clínica. Extrae SOLO los campos solicitados. No inventes datos. Si algo no está, omítelo. Devuelve JSON válido que cumpla con el schema. Usa claves EXACTAS del schema en inglés (patient, symptoms, onsetDays, riskFlags, notes, sex, age). Mantén los valores de texto en el mismo idioma del texto de entrada. No envíes texto fuera del JSON.

--- a/functions/src/extract/index.test.ts
+++ b/functions/src/extract/index.test.ts
@@ -19,12 +19,6 @@ jest.mock("openai", () => {
 
 describe("extract (HTTP Function)", () => {
   const originalEnv = process.env;
-  const prompt =
-    "Eres un asistente de extracción clínica. Extrae SOLO los campos solicitados. " +
-    "No inventes datos. Si algo no está, omítelo. Devuelve JSON válido que cumpla con el schema. " +
-    "Usa claves EXACTAS del schema en inglés (patient, symptoms, onsetDays, riskFlags, notes, sex, age). " +
-    "Mantén los valores de texto en el mismo idioma del texto de entrada. " +
-    "No envíes texto fuera del JSON.";
 
   beforeEach(() => {
     jest.resetModules();
@@ -32,7 +26,6 @@ describe("extract (HTTP Function)", () => {
       ...originalEnv,
       OPENAI_API_KEY: "test-key",
       OPENAI_MODEL: "gpt-4o-mini",
-      LLM_EXTRACT_PROMPT: prompt,
     };
     mockCreate.mockReset();
   });

--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -2,6 +2,8 @@
 import Ajv, { JSONSchemaType } from "ajv";
 import addFormats from "ajv-formats";
 import OpenAI from "openai";
+import { readFileSync } from "fs";
+import path from "path";
 
 export interface ExtractionRequest {
   transcript: string;
@@ -75,6 +77,11 @@ addFormats(ajv);
 const validateRequest = ajv.compile(requestSchema);
 const validateData = ajv.compile(dataSchema as any);
 
+const systemPrompt = readFileSync(
+  path.resolve(__dirname, "../../prompts/llm_extract_prompt.md"),
+  "utf8"
+);
+
 
 function normalizeExtractionData(raw: any): any {
   if (raw == null || typeof raw !== "object") return raw;
@@ -121,8 +128,7 @@ async function extractWithLLM(
   const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
   const openai = new OpenAI({ apiKey });
 
-  const system = process.env.LLM_EXTRACT_PROMPT;
-  if (!system) throw new Error("LLM_EXTRACT_PROMPT no está seteada");
+  const system = systemPrompt;
 
   const user =
     `Texto clínico (lang=${language || "es-AR"}):\n\n${transcript}\n\n` +


### PR DESCRIPTION
## Summary
- store extraction system prompt in `functions/prompts/llm_extract_prompt.md`
- read prompt from file instead of `LLM_EXTRACT_PROMPT` env var
- update tests to remove `LLM_EXTRACT_PROMPT` env usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba746994dc832c80d8579db8b5d987