### PR TITLE
Revert audio language handling

### DIFF
--- a/functions/src/transcribe/service.ts
+++ b/functions/src/transcribe/service.ts
@@ -72,16 +72,13 @@ export async function transcribeService(input: TranscribeInput): Promise<Transcr
   const out = await client.audio.transcriptions.create({
     model: "whisper-1",
     file: uploadable,
-    ...(language ? { language } : {}),
+    language,
     prompt: hint,
-    response_format: "verbose_json",
-  } as any);
-
-  const detected = normalizeLanguage((out as any).language);
+  });
 
   return {
     text: out.text,
-    language: detected || language || "",
+    language: language || "es",
     correlationId: input.correlationId,
   };
 }


### PR DESCRIPTION
## Summary
- Revert fix for audio language handling that rejected unsupported languages
- Restore previous transcription service behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba783712e8832ca700e5b7b7988a41