### PR TITLE
Ensure backend messages use English

### DIFF
--- a/functions/src/extract/service.ts
+++ b/functions/src/extract/service.ts
@@ -124,7 +124,7 @@ async function extractWithLLM(
   language?: string
 ): Promise<ExtractionResponseData> {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error("OPENAI_API_KEY no está seteada");
+  if (!apiKey) throw new Error("OPENAI_API_KEY is not set");
   const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
   const openai = new OpenAI({ apiKey });
 
@@ -152,20 +152,20 @@ async function extractWithLLM(
   });
 
   const content = completion.choices?.[0]?.message?.content;
-  if (!content) throw new Error("LLM devolvió contenido vacío");
+  if (!content) throw new Error("LLM returned empty content");
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
   } catch {
-    throw new Error("LLM no devolvió JSON válido");
+    throw new Error("LLM did not return valid JSON");
   }
 
   const normalized = normalizeExtractionData(parsed);
 
   if (!validateData(normalized)) {
     const errs = JSON.stringify(validateData.errors ?? [], null, 2);
-    throw new Error(`LLM no cumple el schema de extracción: ${errs}`);
+    throw new Error(`LLM output does not match extraction schema: ${errs}`);
   }
 
   const data = normalized as ExtractionResponseData;
@@ -183,7 +183,7 @@ export async function extractService(
   const ok = validateRequest(input);
   if (!ok) {
     throw new Error(
-      "Bad request en extractService: " + JSON.stringify(validateRequest.errors ?? [])
+      "Bad request in extractService: " + JSON.stringify(validateRequest.errors ?? [])
     );
   }
 

--- a/functions/src/pipeline/index.ts
+++ b/functions/src/pipeline/index.ts
@@ -12,7 +12,7 @@ const OPENAI_API_KEY = defineSecret("OPENAI_API_KEY");
 const GEMINI_API_KEY = defineSecret("GEMINI_API_KEY");
 
 const TextInputSchema = z.object({
-  text: z.string().min(1, "text debe ser no vacío"),
+  text: z.string().min(1, "text must be non-empty"),
   language: z.string().default("es-AR").optional(),
   correlationId: z.string().default(() => `corr-${Date.now()}`).optional(),
 });
@@ -56,7 +56,7 @@ app.post("/", async (req: Request, res: Response) => {
     return res.status(400).json({
       ok: false,
       step: "validation",
-      error: "Body inválido",
+      error: "Invalid body",
       details: parsed.error.issues,
     });
   }
@@ -99,7 +99,7 @@ app.post("/", async (req: Request, res: Response) => {
       if (!tr?.text) {
         return res
           .status(500)
-          .json({ ok: false, step: "transcribe", error: "Transcription sin texto" });
+          .json({ ok: false, step: "transcribe", error: "Transcription has no text" });
       }
       transcript = tr.text;
       language = input.language ?? tr.language ?? "es-AR";
@@ -165,13 +165,13 @@ app.post("/", async (req: Request, res: Response) => {
     return res.status(500).json({
       ok: false,
       step: "unknown",
-      error: e?.message ?? "Error inesperado",
+      error: e?.message ?? "Unexpected error",
     });
   }
 });
 
 app.use((_req: Request, res: Response) => {
-  res.status(405).json({ ok: false, error: "Usa POST /" });
+  res.status(405).json({ ok: false, error: "Use POST /" });
 });
 
 // -------- Export Cloud Function --------

--- a/functions/src/transcribe/index.test.ts
+++ b/functions/src/transcribe/index.test.ts
@@ -37,14 +37,14 @@ describe("transcribe (contrato JSON + raw fallback)", () => {
   });
 
   // ---------- JSON inválido ----------
-  it("JSON inválido → 400 (falta audio.type/value)", async () => {
+  it("Invalid JSON → 400 (missing audio.type/value)", async () => {
     const app = buildJsonApp();
     const res = await request(app)
       .post("/")
       .set("Content-Type", "application/json")
       .send({ audio: { type: "url" } }); // falta value
     expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/JSON inválido/i);
+    expect(res.body.error).toMatch(/Invalid JSON/i);
   });
 
   // ---------- JSON con URL ----------
@@ -94,14 +94,14 @@ describe("transcribe (contrato JSON + raw fallback)", () => {
   });
 
   // ---------- RAW vacío ----------
-  it("Raw vacío → 400", async () => {
+  it("Empty raw body → 400", async () => {
     const app = buildJsonApp();
     const res = await request(app)
       .post("/")
       .set("Content-Type", "audio/ogg")
       .send(); // sin body
     expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/Body vacío/i);
+    expect(res.body.error).toMatch(/Empty body/i);
   });
 
   // ---------- RAW feliz ----------
@@ -117,14 +117,14 @@ describe("transcribe (contrato JSON + raw fallback)", () => {
   });
 
   // ---------- Error proveedor ----------
-  it("Error en proveedor → 500", async () => {
-    createMock.mockRejectedValueOnce(new Error("Falla simulada"));
+  it("Provider error → 500", async () => {
+    createMock.mockRejectedValueOnce(new Error("Simulated failure"));
     const app = buildJsonApp();
     const res = await request(app)
       .post("/")
       .set("Content-Type", "audio/ogg")
       .send(Buffer.from("FAKE"));
     expect(res.status).toBe(500);
-    expect(res.body.error).toMatch(/Falla simulada|Error procesando/i);
+    expect(res.body.error).toMatch(/Simulated failure|Error processing/i);
   });
 });

--- a/functions/src/transcribe/index.ts
+++ b/functions/src/transcribe/index.ts
@@ -27,7 +27,7 @@ export async function transcribeHandler(req: any, res: any): Promise<void> {
     }
 
     if (!body || !body.audio || !body.audio.type || !body.audio.value) {
-      res.status(400).json({ error: "JSON inválido: se espera audio: { type: 'url'|'base64', value: '...' }" });
+      res.status(400).json({ error: "Invalid JSON: expected audio: { type: 'url'|'base64', value: '...' }" });
       return;
     }
 
@@ -46,7 +46,8 @@ export async function transcribeHandler(req: any, res: any): Promise<void> {
       });
       return;
     } catch (e: any) {
-      const msg = e?.response?.data?.error?.message || e?.message || "Error procesando transcripción";
+      const msg =
+        e?.response?.data?.error?.message || e?.message || "Error processing transcription";
       res.status(500).json({ error: msg });
       return;
     }
@@ -54,7 +55,7 @@ export async function transcribeHandler(req: any, res: any): Promise<void> {
 
   const raw = req.body as Buffer;
   if (!raw || !Buffer.isBuffer(raw) || raw.length === 0) {
-    res.status(400).json({ error: "Body vacío; envía JSON con audio.url/base64 o audio binario con --data-binary" });
+    res.status(400).json({ error: "Empty body; send JSON with audio.url/base64 or binary audio with --data-binary" });
     return;
   }
 
@@ -71,7 +72,8 @@ export async function transcribeHandler(req: any, res: any): Promise<void> {
     res.json({ text: out.text });
     return;
   } catch (e: any) {
-    const msg = e?.response?.data?.error?.message || e?.message || "Error procesando transcripción";
+    const msg =
+      e?.response?.data?.error?.message || e?.message || "Error processing transcription";
     res.status(500).json({ error: msg });
     return;
   }

--- a/functions/src/transcribe/service.ts
+++ b/functions/src/transcribe/service.ts
@@ -40,7 +40,7 @@ export async function transcribeService(input: TranscribeInput): Promise<Transcr
 
   if (input.audio.type === "url") {
     const r = await fetch(input.audio.value);
-    if (!r.ok) throw new Error(`No se pudo descargar el audio: ${r.status}`);
+    if (!r.ok) throw new Error(`Failed to download audio: ${r.status}`);
     const ab = await r.arrayBuffer();
     buf = Buffer.from(ab);
     mime = r.headers.get("content-type") || "application/octet-stream";
@@ -59,7 +59,7 @@ export async function transcribeService(input: TranscribeInput): Promise<Transcr
     if (m) mime = m[1];
   }
 
-  if (!buf || buf.length === 0) throw new Error("Audio vacío o inválido");
+  if (!buf || buf.length === 0) throw new Error("Empty or invalid audio");
 
   const uploadable = await toFile(buf, filename, { type: mime });
   const language = normalizeLanguage(input.language);


### PR DESCRIPTION
## Summary
- translate pipeline validation and error responses to English
- translate transcribe and extract service messages to English
- update tests for new English wording

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected space(s) before '}' ... 428 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d83c278832c92a76a2151a0fa89